### PR TITLE
ci(settings): Update path of CodeOwners

### DIFF
--- a/standardized-workflows/all/settings.yml
+++ b/standardized-workflows/all/settings.yml
@@ -55,7 +55,7 @@ batch_file_operations:
   - target_branch: main
     commit_msg: 'ci(standards): Update Standard Workflows'
     files:
-      - src_file: CODEOWNERS
+      - src_file: .github/CODEOWNERS
         dest_file: CODEOWNERS
       - src_file: standardized-workflows/all/workflows/codeowners.yml
         dest_file: .github/workflows/codeowners.yml

--- a/standardized-workflows/all/settings.yml
+++ b/standardized-workflows/all/settings.yml
@@ -56,7 +56,7 @@ batch_file_operations:
     commit_msg: 'ci(standards): Update Standard Workflows'
     files:
       - src_file: .github/CODEOWNERS
-        dest_file: CODEOWNERS
+        dest_file: .github/CODEOWNERS
       - src_file: standardized-workflows/all/workflows/codeowners.yml
         dest_file: .github/workflows/codeowners.yml
       - src_file: standardized-workflows/all/workflows/conventional-commits.yml


### PR DESCRIPTION
# Description
Updated path for codeowners

## Motivation and Context
Standardize location of codeowners to be in the .github subdirectory.